### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,9 +19,9 @@ dependencies:
     - groq
     - ocp_tessellate
     - ocp_vscode
-    - pyautogen
+    - ag2
     - tiktoken
     - autogen[retrievechat]
-    - pyautogen[gemini]
+    - ag2[gemini]
     - flaml[automl]
     - streamlit_stl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ cadquery-ocp==7.7.2
 groq==0.11.0
 ocp_tessellate==3.0.4
 ocp_vscode==2.4.1
-pyautogen==0.3.0
+ag2==0.3.0
 setuptools==73.0.1
 tiktoken==0.7.0
 autogen[retrievechat]
-pyautogen[gemini]
+ag2[gemini]
 flaml[automl]
 open3d
 streamlit


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
